### PR TITLE
Fixed NPE in RedisSessionManager#save()

### DIFF
--- a/src/main/java/com/radiadesign/catalina/session/RedisSessionManager.java
+++ b/src/main/java/com/radiadesign/catalina/session/RedisSessionManager.java
@@ -455,7 +455,8 @@ public class RedisSessionManager extends ManagerBase implements Lifecycle {
 
       jedis = acquireConnection();
 
-      if (sessionIsDirty || currentSessionIsPersisted.get() != true) {
+      Boolean isCurrentSessionPersisted = this.currentSessionIsPersisted.get();
+      if (sessionIsDirty || (isCurrentSessionPersisted == null || !isCurrentSessionPersisted)) {
         jedis.set(binaryId, serializer.serializeFrom(redisSession));
       }
 


### PR DESCRIPTION
Hi,

I stumbled across an NPE in RedisSessionManager#save() that occurs if currentSessionIsPersisted is not set.

Please see attached fix.

Kind regards,
Janko
