### PR TITLE
Adding sentinel support.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,8 @@ repositories {
 }
 
 dependencies {
-  compile group: 'org.apache.tomcat', name: 'tomcat-catalina', version: '7.0.27'
-  compile group: 'redis.clients', name: 'jedis', version: '2.0.0'
+  compile group: 'org.apache.tomcat', name: 'tomcat-catalina', version: '7.0.50'
+  compile group: 'redis.clients', name: 'jedis', version: '2.2.1'
   // compile group: 'commons-collections', name: 'commons-collections', version: '3.2'
   // testCompile group: 'junit', name: 'junit', version: '4.+'
 }

--- a/src/main/java/com/radiadesign/catalina/session/RedisSessionManager.java
+++ b/src/main/java/com/radiadesign/catalina/session/RedisSessionManager.java
@@ -1,28 +1,18 @@
 package com.radiadesign.catalina.session;
 
-import org.apache.catalina.Lifecycle;
-import org.apache.catalina.LifecycleException;
-import org.apache.catalina.LifecycleListener;
-import org.apache.catalina.util.LifecycleSupport;
-import org.apache.catalina.LifecycleState;
-import org.apache.catalina.Loader;
-import org.apache.catalina.Valve;
-import org.apache.catalina.Session;
+import org.apache.catalina.*;
 import org.apache.catalina.session.ManagerBase;
-
-import redis.clients.jedis.JedisPool;
-import redis.clients.jedis.JedisPoolConfig;
-import redis.clients.jedis.Jedis;
-import redis.clients.jedis.Protocol;
+import org.apache.catalina.util.LifecycleSupport;
+import org.apache.juli.logging.Log;
+import org.apache.juli.logging.LogFactory;
+import redis.clients.jedis.*;
+import redis.clients.util.Pool;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Enumeration;
+import java.util.HashSet;
 import java.util.Set;
-
-import org.apache.juli.logging.Log;
-import org.apache.juli.logging.LogFactory;
 
 
 public class RedisSessionManager extends ManagerBase implements Lifecycle {
@@ -36,7 +26,9 @@ public class RedisSessionManager extends ManagerBase implements Lifecycle {
   protected int database = 0;
   protected String password = null;
   protected int timeout = Protocol.DEFAULT_TIMEOUT;
-  protected JedisPool connectionPool;
+  protected Pool<Jedis> connectionPool;
+  protected String master = null;
+  protected String sentinels = null;
 
   protected RedisSessionHandlerValve handlerValve;
   protected ThreadLocal<RedisSession> currentSession = new ThreadLocal<RedisSession>();
@@ -91,6 +83,27 @@ public class RedisSessionManager extends ManagerBase implements Lifecycle {
 
   public void setPassword(String password) {
     this.password = password;
+  }
+
+  public String getSentinels() {
+    return sentinels;
+  }
+
+  public void setSentinels(String sentinels) {
+    this.sentinels = sentinels;
+  }
+
+  public Set<String> getSentinelSet(){
+    String[] sentinels = getSentinels().split(",");
+    return new HashSet<String>(Arrays.asList(sentinels));
+  }
+
+  public String getMaster() {
+    return master;
+  }
+
+  public void setMaster(String master) {
+    this.master = master;
   }
 
   public void setSerializationStrategyClass(String strategy) {
@@ -520,7 +533,13 @@ public class RedisSessionManager extends ManagerBase implements Lifecycle {
   private void initializeDatabaseConnection() throws LifecycleException {
     try {
       // TODO: Allow configuration of pool (such as size...)
-      connectionPool = new JedisPool(new JedisPoolConfig(), getHost(), getPort(), getTimeout(), getPassword());
+      if (getMaster() != null && getSentinels() != null)     {
+        connectionPool = new JedisSentinelPool(getMaster(), getSentinelSet(), new JedisPoolConfig(), getTimeout(), getPassword());
+      } else if (getMaster() != null || getSentinels() != null)  {
+        log.warn("To use redis sentinel, both the master and sentinel properties must be set.");
+      } else {
+        connectionPool = new JedisPool(new JedisPoolConfig(), getHost(), getPort(), getTimeout(), getPassword());
+      }
     } catch (Exception e) {
       e.printStackTrace();
       throw new LifecycleException("Error Connecting to Redis", e);


### PR DESCRIPTION
Implementing support for redis sentinel. Upgrading JEDIS to 2.2.1 which has the JedisSentinelPool. The build jar from the java7/tomcat7 branch that I made worked fine and this code was copied over for the pull request.

Addresses Issue #20.
