### PR TITLE
Fix improper millisecond conversion of inactive timeout

### DIFF
--- a/src/main/java/com/orangefunction/tomcat/redissessions/RedisSessionManager.java
+++ b/src/main/java/com/orangefunction/tomcat/redissessions/RedisSessionManager.java
@@ -533,7 +533,7 @@ public class RedisSessionManager extends ManagerBase implements Lifecycle {
 
       session.setId(id);
       session.setNew(false);
-      session.setMaxInactiveInterval(getMaxInactiveInterval() * 1000);
+      session.setMaxInactiveInterval(getMaxInactiveInterval());
       session.access();
       session.setValid(true);
       session.resetDirtyTracking();


### PR DESCRIPTION
When creating a new session, the `RedisSessionManager` was correctly setting the sessions `MaxInactiveInterval` to the manager's `getMaxInactiveInterval()`, but when deserializing a redis session it set it to `getMaxInactiveInterval() * 1000`, thus mis-representing the expiration time of the session.