### PR TITLE
Do not wipe out current session when calling findSession with other session IDs

### DIFF
--- a/src/main/java/com/orangefunction/tomcat/redissessions/RedisSessionManager.java
+++ b/src/main/java/com/orangefunction/tomcat/redissessions/RedisSessionManager.java
@@ -422,10 +422,7 @@ public class RedisSessionManager extends ManagerBase implements Lifecycle {
     RedisSession session = null;
 
     if (null == id) {
-      currentSessionIsPersisted.set(false);
-      currentSession.set(null);
-      currentSessionSerializationMetadata.set(null);
-      currentSessionId.set(null);
+      return null;
     } else if (id.equals(currentSessionId.get())) {
       session = currentSession.get();
     } else {
@@ -433,15 +430,6 @@ public class RedisSessionManager extends ManagerBase implements Lifecycle {
       if (data != null) {
         DeserializedSessionContainer container = sessionFromSerializedData(id, data);
         session = container.session;
-        currentSession.set(session);
-        currentSessionSerializationMetadata.set(container.metadata);
-        currentSessionIsPersisted.set(true);
-        currentSessionId.set(id);
-      } else {
-        currentSessionIsPersisted.set(false);
-        currentSession.set(null);
-        currentSessionSerializationMetadata.set(null);
-        currentSessionId.set(null);
       }
     }
 


### PR DESCRIPTION
The contract of `o.a.c.Manager.findSession` is to just return the active session that matches the passed in session ID and does not specify any side-effects with the current session. In the current implementation if you ask for a session that's not the current session it changes the `currentSession` ThreadLocal which will then cause the current session to not be persisted in `afterRequest`. 

We ran into this problem with Spring Security's session fixation prevention: 
* User loads login page in the browser and remains idle long enough for the session to expire
* User uses login page to log in
* The request will include an expired session ID. When tomcat can't find the session it will create a new session with a new ID.
* The session fixation prevention code will look to see if the requested session ID was valid (it doesn't need to create a new session if the one asked for isn't being used). The implementation of this will call `Manager.findSession` with the original requested session ID
* The tomcat redis session manager will then wipe out the `currentSession` ThreadLocal causing the current session to not be persisted

If I understand the reasoning behind the implementation, you were trying to make sure the session requested gets persisted in case the caller mutates the returned session. But this leads to the existing, valid, current session not getting persisted. To make sure both the current session and any sessions asked for by `findSession` get persisted there needs to be a mechanism to track all sessions returned by `findSession` that are not the currentSession and make sure those are persisted after the request. However, that's complicated by the fact that multiple concurrent threads could have called findSession for the same session ID. I feel like the implementation should at least honor the currentSession without wiping it out on calls to `findSession`. Best case you've asked for the currentSession, which just returns that existing object, worst case you're asking for other sessions and even the current implementation can't guarantee that the session object returned will get persisted, just the last one asked for.