### PR TITLE
Fix duplicating jvmRoute prefixes on sessionIds.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ example-app/build/*
 example-app/.gradle/*
 .DS_Store
 .rspec
+*.iml
+.idea/*

--- a/src/main/java/com/orangefunction/tomcat/redissessions/RedisSessionManager.java
+++ b/src/main/java/com/orangefunction/tomcat/redissessions/RedisSessionManager.java
@@ -344,19 +344,13 @@ public class RedisSessionManager extends ManagerBase implements Lifecycle {
 
       // Ensure generation of a unique session identifier.
       if (null != requestedSessionId) {
-        sessionId = requestedSessionId;
-        if (jvmRoute != null) {
-          sessionId += '.' + jvmRoute;
-        }
+        sessionId = sessionIdWithJvmRoute(requestedSessionId, jvmRoute);
         if (jedis.setnx(sessionId.getBytes(), NULL_SESSION) == 0L) {
           sessionId = null;
         }
       } else {
         do {
-          sessionId = generateSessionId();
-          if (jvmRoute != null) {
-            sessionId += '.' + jvmRoute;
-          }
+          sessionId = sessionIdWithJvmRoute(generateSessionId(), jvmRoute);
         } while (jedis.setnx(sessionId.getBytes(), NULL_SESSION) == 0L); // 1 = key set; 0 = key already existed
       }
 
@@ -400,6 +394,14 @@ public class RedisSessionManager extends ManagerBase implements Lifecycle {
     }
 
     return session;
+  }
+
+  private String sessionIdWithJvmRoute(String sessionId, String jvmRoute) {
+    if (jvmRoute != null) {
+      String jvmRoutePrefix = '.' + jvmRoute;
+      return sessionId.endsWith(jvmRoutePrefix) ? sessionId : sessionId + jvmRoutePrefix;
+    }
+    return sessionId;
   }
 
   @Override


### PR DESCRIPTION
In our Tomcat 7.0.59 environment (with Apache 2.2-based  MOD_JK loadbalancer nodes) the Redis Session Manager does not work because sessionIds end up in redis with incorrect prefix.

It seems that the requestedSessionId already contains a jvmRoute-based prefix and blindly adding it again in RedisSessionManager.createSession() is wrong. This commit adds a safeguard for that.

Fixed our problem at least and should be safe for others as well :-)