### PR TITLE
jvmRoute as part of the Redis key prevents failover to other nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,6 @@ example-app/.gradle/*
 .DS_Store
 .rspec
 *.iml
+*.ipr
+*.iws
 .idea/*

--- a/src/test/java/com/orangefunction/tomcat/redissessions/RedisSessionManagerTest.java
+++ b/src/test/java/com/orangefunction/tomcat/redissessions/RedisSessionManagerTest.java
@@ -1,0 +1,56 @@
+package com.orangefunction.tomcat.redissessions;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * User: Kai Inkinen <kai.inkinen@futurice.com>
+ * Date: 2015.05.04
+ * Time: 10:15
+ */
+public class RedisSessionManagerTest {
+
+    private RedisSessionManager manager;
+    private String[] randomJvmRoutes = new String[]{"abc", "123", "abc123", "......", "1.1.2.jvmRoute", ",.,..,.,"};
+
+    @Before
+    public final void setupRedisSessionManagerTest() {
+        manager = new RedisSessionManager();
+    }
+
+    @Test
+    public void sessionIdWithoutJvmRouteIsReturned() {
+        assertEquals("session", manager.stripJvmRoute("session", "jvmRoute"));
+    }
+
+    @Test
+    public void nullReturnedAsIs() {
+        assertNull(manager.stripJvmRoute(null, "jvmRoute"));
+        assertNull(manager.stripJvmRoute(null, null));
+    }
+
+    @Test
+    public void sessionIdIsNotModifiedIfWeDontHaveAJvmRoute() {
+        for (String jvmRoute : randomJvmRoutes) {
+            assertEquals("session." + jvmRoute, manager.stripJvmRoute("session." + jvmRoute, null));
+        }
+    }
+
+    @Test
+    public void sessionIdWithAnyJvmRouteIsModified() {
+        for (String jvmRoute : randomJvmRoutes) {
+            assertEquals("session", manager.stripJvmRoute("session." + jvmRoute, "unknown" + jvmRoute));
+        }
+    }
+
+    @Test
+    public void generatedSessionStripsJvmRoute() {
+        for (String jvmRoute : randomJvmRoutes) {
+            assertEquals("session", manager.stripJvmRoute("session." + jvmRoute, jvmRoute));
+        }
+    }
+
+}


### PR DESCRIPTION
Including the jvmRoute as part of the redis key prevents migrating the session to another node. This applies both to failover because a node dies, as well as normal round-robin load balancing. 

Quoting the memcached session plugin FAQ (https://code.google.com/p/memcached-session-manager/wiki/FAQ): 
> If you want to go for the servlet filter with sticky sessions, you also need to strip the jvmRoute off the sessionId to get the memcached key (in the case tomcats are configured with a jvmRoute). Otherwise, when the sessionId including the jvmRoute would be used as memcached key, the key would change on a tomcat failover as the jvmRoute is then changed to the one of the tomcat that is taking over the session.

This pull request modifies the key used in redis by stripping the jvmRoute from it. This way any node in the cluster can fetch the same value using the session id. Stripping the key happens both for newly generated session ids, as well as the ones coming from the customer. 

This current implementation assumes that if the jvmRoute is not set, i.e. is null, then the session id is not tampered with. 

The pull request contains some very basic sanity tests for the strip method, to make sure no unwarranted exceptions are thrown, and that the stripping logic works for various special cases. 
