### PR TITLE
RedisSessionManager will throw NullPointerException

### DIFF
--- a/src/main/java/com/radiadesign/catalina/session/RedisSessionManager.java
+++ b/src/main/java/com/radiadesign/catalina/session/RedisSessionManager.java
@@ -407,7 +407,7 @@ public class RedisSessionManager extends ManagerBase implements Lifecycle {
 
       jedis = acquireConnection();
 
-      if (sessionIsDirty || currentSessionIsPersisted.get() != true) {
+      if (sessionIsDirty || currentSessionIsPersisted.get() == null || currentSessionIsPersisted.get() != true) {
         jedis.set(binaryId, serializer.serializeFrom(redisSession));
       }
 


### PR DESCRIPTION
if currentSessionIsPersisted.get() is null, the follow code :

    currentSessionIsPersisted.get() != true

will throw a NullPointerException.